### PR TITLE
Add concept map heading for E2E visibility check

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,15 @@ import './components/ConceptMap.css'
 function App() {
   return (
     <div className="App">
+      {/**
+       * A simple heading gives the page a recognisable anchor.  Both
+       * human visitors and automated tests use it to confirm the
+       * interface has loaded.  The inline style keeps dependencies light
+       * while centring the text on screen.
+       */}
+      <h1 style={{ textAlign: 'center', fontSize: '1.5rem', margin: '0.5rem 0' }}>
+        Interactive Concept Map
+      </h1>
       <ConceptMapVisualization />
     </div>
   )


### PR DESCRIPTION
## Summary
- render a visible "Interactive Concept Map" heading so Playwright tests can detect the page has loaded

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: Process from config.webServer was not able to start. Exit code: 2)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ee8d906483238820e425f8216a6c