### PR TITLE
feat: allow deep-linking to datasets via URL

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -44,6 +44,11 @@ npm run dev
 # http://localhost:5173/?jsonUrl=https://raw.githubusercontent.com/jdoner02/concept-map-d3js/refs/heads/main/src/main/resources/concept-map.json
 # or simply reference a bundled file by name:
 # http://localhost:5173/?jsonUrl=hrv-research-nodes-v1.json
+
+# Preselect a dataset from the bundled manifest (sets dropdown & shareable link)
+# http://localhost:5173/?dataset=hrv-research-nodes-v1.json
+# or the hash-based equivalent if you prefer:
+# http://localhost:5173/#dataset=hrv-research-nodes-v1.json
 ```
 
 Notes:


### PR DESCRIPTION
## Summary
- allow pre-selecting datasets via `?dataset=` or `#dataset=` in ConceptMapVisualization and update URL when user selects a dataset
- document dataset linking with examples

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:e2e` *(fails: Process from config.webServer was not able to start)*
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a4009175108323805b087335832a66