### PR TITLE
feat: auto-generate dataset manifest

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,12 +4,15 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-  "dev": "vite --host 127.0.0.1 --port 5173 --strictPort",
+    "dev": "vite --host 127.0.0.1 --port 5173 --strictPort",
     "build": "vite build",
     "lint": "eslint .",
-  "preview": "vite preview --host 127.0.0.1 --port 5174",
-  "test:e2e": "playwright test",
-  "test:e2e:headed": "playwright test --headed"
+    "preview": "vite preview --host 127.0.0.1 --port 5174",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "generate-manifest": "node scripts/generate-manifest.mjs",
+    "predev": "node scripts/generate-manifest.mjs",
+    "prebuild": "node scripts/generate-manifest.mjs"
   },
   "dependencies": {
     "@types/d3": "^7.4.3",
@@ -26,7 +29,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-  "vite": "^7.1.2",
-  "@playwright/test": "^1.49.0"
+    "vite": "^7.1.2",
+    "@playwright/test": "^1.49.0"
   }
 }

--- a/frontend/public/data/manifest.json
+++ b/frontend/public/data/manifest.json
@@ -1,8 +1,26 @@
 [
-  { "file": "old-concept-map.json",       "name": "CSCD211 Concept Map" },
-  { "file": "hrv-research-nodes-v1.json", "name": "HRV Research Map" },
-  { "file": "concept-map-preview.research.json", "name": "HRV Research Map v2" },
-  { "file": "ewu-course-catalog.json",    "name": "EWU Course Catalog" },
-  { "file": "cscd210-decomposed.json",    "name": "CSCD210 Concept Map" },
-  { "file": "cscd211-decomposed.json",    "name": "CSCD211 Concept Map (V2)" }
+  {
+    "file": "concept-map-preview.research.json",
+    "name": "Apple Watch Ecg Clinical Validation"
+  },
+  {
+    "file": "hrv-research-nodes-v1.json",
+    "name": "Consumer Wearable-Based Autonomic Monitoring for Neuropsychiatric Stress Response Detection"
+  },
+  {
+    "file": "cscd210-decomposed.json",
+    "name": "CSCD 210 Programming Principles I"
+  },
+  {
+    "file": "cscd211-decomposed.json",
+    "name": "CSCD 211: Programming Principles II (cscd211-decomposed.json)"
+  },
+  {
+    "file": "old-concept-map.json",
+    "name": "CSCD 211: Programming Principles II (old-concept-map.json)"
+  },
+  {
+    "file": "ewu-course-catalog.json",
+    "name": "EWU Official Course Catalog"
+  }
 ]

--- a/frontend/scripts/generate-manifest.mjs
+++ b/frontend/scripts/generate-manifest.mjs
@@ -1,0 +1,55 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+// Generate a manifest of available concept-map datasets by scanning the
+// public/data directory.  This keeps the dropdown in sync whenever JSON
+// files are added or removed without relying on manual edits.
+async function main() {
+  const dataDir = new URL('../public/data/', import.meta.url);
+  const files = await readdir(dataDir);
+  const datasets = [];
+
+  for (const file of files) {
+    // Only consider JSON files; ignore the manifest itself and auxiliary data
+    if (!file.endsWith('.json') || file === 'manifest.json' || file.startsWith('term_')) {
+      continue;
+    }
+
+    const fileUrl = new URL(file, dataDir);
+    let name = path.basename(file, '.json');
+
+    try {
+      const raw = await readFile(fileUrl, 'utf8');
+      const json = JSON.parse(raw);
+      // Prefer explicit titles; fall back to first node's name or filename
+      name = json?.metadata?.name || json?.metadata?.title || json?.nodes?.[0]?.name || name;
+    } catch (err) {
+      // If a file fails to parse we still include it with its filename-based name
+      console.warn(`Could not parse ${file}:`, err);
+    }
+
+    datasets.push({ file, name });
+  }
+
+  // Sort for stable ordering in the UI
+  datasets.sort((a, b) => a.name.localeCompare(b.name));
+
+  // If two datasets report the same display name we append the filename so
+  // users can still distinguish them in the dropdown.
+  const counts = datasets.reduce((acc, d) => {
+    acc[d.name] = (acc[d.name] || 0) + 1;
+    return acc;
+  }, {});
+  for (const d of datasets) {
+    if (counts[d.name] > 1) d.name += ` (${d.file})`;
+  }
+
+  const manifestPath = new URL('manifest.json', dataDir);
+  await writeFile(manifestPath, JSON.stringify(datasets, null, 2) + '\n');
+  console.log(`Wrote ${datasets.length} entries to`, manifestPath.pathname);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- auto-build manifest of available concept-map datasets
- run manifest generation before dev and build to keep dropdown options fresh
- capture duplicate dataset names by appending file names so CSCD211 V2 is selectable

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: Process from config.webServer was not able to start)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4102ff60c83238a62a181efadb16a