### PR TITLE
fix: tame dataset dropdown width and expose controls on mobile

### DIFF
--- a/frontend/src/components/ConceptMap.css
+++ b/frontend/src/components/ConceptMap.css
@@ -23,6 +23,11 @@
   border-radius: 6px;
   font-size: 0.9em;
   z-index: 12;
+  /* Constrain total width so the bar never collides with other floating UI. */
+  max-width: 90vw;
+  /* Allow items to wrap on very narrow screens instead of overflowing. */
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .concept-map-header select {
@@ -32,6 +37,12 @@
   border-radius: 4px;
   background: #fff;
   font-size: 0.9em;
+  /* Cap width so long dataset names do not shove neighbouring controls. */
+  max-width: 180px;
+  /* Let the browser shrink the control when space is tight. */
+  width: auto;
+  /* Prevent the label text from wrapping onto multiple lines. */
+  white-space: nowrap;
 }
 
 .metadata {

--- a/frontend/src/components/ConceptMapVisualization.jsx
+++ b/frontend/src/components/ConceptMapVisualization.jsx
@@ -2298,6 +2298,37 @@ const ConceptMapVisualization = () => {
           <div className="mobile-panel" role="dialog" aria-modal="true" aria-label="Options and filters" tabIndex={0} onKeyDown={(e)=>{ if(e.key==='Escape') setMobilePanelOpen(false); }}>
             <div className="handle" />
             <div className="content">
+              {datasets.length > 0 && (
+                <div className="section">
+                  <h3>Dataset</h3>
+                  {/**
+                   * Reuse the same stateful dropdown as the desktop header but
+                   * style it for touch.  Constraining the width keeps long
+                   * dataset names readable without forcing sideways scrolling.
+                   */}
+                  <select
+                    id="dataset-select-mobile"
+                    aria-label="Dataset"
+                    value={selectedDataset || ''}
+                    onChange={(e) => setSelectedDataset(e.target.value)}
+                    style={{ width: '100%', padding: '8px 10px', border: '1px solid #ddd', borderRadius: 8 }}
+                  >
+                    {datasets.map((ds) => (
+                      <option key={ds.file} value={ds.file}>{ds.name}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              {data?.metadata && (
+                <div className="section" style={{ fontSize: 14 }}>
+                  <h3>Rendered</h3>
+                  {/**
+                   * Mirror the live node/link counts so mobile users can gauge
+                   * graph size without hunting for the desktop-only header.
+                   */}
+                  <p>Nodes: {renderCounts.nodes} • Links: {renderCounts.links}</p>
+                </div>
+              )}
               <div className="section">
                 <h3>Search</h3>
                 <div style={{ display: 'flex', gap: 8 }}>


### PR DESCRIPTION
## Summary
- prevent dataset picker from stretching the top header by capping its width and wrapping when space is tight
- surface dataset picker and live node/link counts inside the mobile bottom sheet

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: export: Illegal option -a)*
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68a417c2f23c832388a9f1f8bc3c1d23