### PR TITLE
feat: add arrow pointer to node tooltips

### DIFF
--- a/frontend/src/components/ConceptMap.css
+++ b/frontend/src/components/ConceptMap.css
@@ -290,5 +290,27 @@ title {
 .mobile-panel .section { padding: 8px 0; border-top: 1px solid #eee; }
 
 @media (max-width: 768px) {
-  .mobile-panel { display: block; }
+.mobile-panel { display: block; }
+}
+
+/*
+ * Draw a small arrow on the detailed node tooltip.  A ::before pseudo-element
+ * is lighter than extra markup yet still gives the eye a pointer back to the
+ * node that spawned the card.
+ */
+.node-tooltip::before {
+  content: "";
+  position: absolute;
+  width: 0;
+  height: 0;
+  /* Craft a right‑angled triangle that leans toward the node */
+  border: 8px solid transparent;
+  border-bottom-color: rgba(255, 255, 255, 0.98);
+  border-right-color: rgba(255, 255, 255, 0.98);
+  /* Anchor the arrow slightly above and left of the card */
+  top: -8px;
+  left: -8px;
+  /* Outline mirrors the tooltip border so the arrow feels attached */
+  box-shadow: -1px -1px 0 0 #e0e0e0;
+  z-index: -1;
 }

--- a/frontend/src/components/ConceptMapVisualization.jsx
+++ b/frontend/src/components/ConceptMapVisualization.jsx
@@ -2521,8 +2521,13 @@ const ConceptMapVisualization = () => {
         <div
           ref={tooltipDivRef}
           data-testid="node-tooltip"
+          className="node-tooltip"
           /*
-           * Visually this container resembles a small card.  Cards are a
+           * We attach a class so CSS can draw a tiny triangular pointer using
+           * a ::before pseudo‑element.  This anchors the floating card back to
+           * the node it describes, sparing readers the "which one?" confusion.
+           *
+           * Visually the container itself resembles a small card.  Cards are a
            * familiar pattern across mobile and desktop UIs, so reusing the
            * style makes the tooltip feel instantly recognisable and polished.
            */


### PR DESCRIPTION
## Summary
- add `node-tooltip` class to tooltip so CSS can attach an arrow
- craft `.node-tooltip::before` pseudo-element to draw a triangular pointer toward its node

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4cf8f12a483239f36f2a67fc74702